### PR TITLE
[BUG] Fix bug with unclosed div element

### DIFF
--- a/classes/QM_Output_Memcache_Stats.php
+++ b/classes/QM_Output_Memcache_Stats.php
@@ -62,6 +62,7 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 			echo '</tbody>';
 			echo '</table>';
 		}
+		echo '</div>';
 	}
 
 	/**


### PR DESCRIPTION
This plugin was not closing the primary div for the qm section.

This meant that some other sections were unavailable (including
configuration section, capability checks, and jetpack search section.)