### PR TITLE
[CONFIG] Add PHPCS & Travis integration.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.php]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+php:
+  - 7.3
+
+install:
+  - composer install
+
+script:
+  - "./vendor/bin/phpcs ."

--- a/class-qm-memcache-stats.php
+++ b/class-qm-memcache-stats.php
@@ -13,14 +13,11 @@
  * Class QM_Collector_Memcache
  */
 class QM_Memcache_Stats {
-
 	public function __construct() {
-
 		if ( class_exists( 'QM_Collectors' ) ) {
 			$this->register_collector();
 			add_filter( 'qm/outputter/html', array( $this, 'register_output' ), 101, 1 );
 		}
-
 	}
 
 	/*
@@ -29,8 +26,8 @@ class QM_Memcache_Stats {
 	 * @return void
 	 */
 	private function register_collector() {
-			require_once( 'classes/QM_Collector_Memcache_Stats.php' );
-			QM_Collectors::add( new QM_Collector_Memcache_Stats() );
+		require_once 'classes/class-qm-collector-memcache-stats.php';
+		QM_Collectors::add( new QM_Collector_Memcache_Stats() );
 	}
 
 	/*
@@ -40,18 +37,23 @@ class QM_Memcache_Stats {
 	 *
 	 * @return array
 	 */
-	public function register_output( $output ) {
-		require_once( 'classes/QM_Output_Memcache_Stats.php' );
+	public function register_output( array $output ): array {
+		require_once 'classes/class-qm-output-memcache-stats.php';
 
-		if ( $collector = QM_Collectors::get( 'memcache-stats' ) ) {
+		$collector = QM_Collectors::get( 'memcache-stats' );
+		if ( isset( $collector ) ) {
 			$output['memcache'] = new QM_Output_Memcache_Stats( $collector );
 		}
 
 		return $output;
 	}
-
 }
 
-add_action( 'plugins_loaded', function () {
-	new QM_Memcache_Stats();
-}, 10, 0 );
+add_action(
+	'plugins_loaded',
+	function () {
+		new QM_Memcache_Stats();
+	},
+	10,
+	0
+);

--- a/classes/class-qm-collector-memcache-stats.php
+++ b/classes/class-qm-collector-memcache-stats.php
@@ -4,13 +4,12 @@
  * Class QM_Collector_Memcache
  */
 class QM_Collector_Memcache_Stats extends QM_Collector {
-
 	public $id = 'memcache-stats';
 
 	/**
 	 * @return string
 	 */
-	public function name() {
+	public function name(): string {
 		return esc_html__( 'Memcache Stats', 'query-monitor' );
 	}
 
@@ -19,5 +18,4 @@ class QM_Collector_Memcache_Stats extends QM_Collector {
 	 */
 	public function process() {
 	}
-
 }

--- a/classes/class-qm-output-memcache-stats.php
+++ b/classes/class-qm-output-memcache-stats.php
@@ -27,7 +27,7 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 		echo '<thead>';
 		echo '<tr>';
 		foreach ( $wp_object_cache->stats as $stat => $n ) {
-			echo '<th scope="col">' . sprintf( esc_html__( 'Memcache %s', 'query-monitor' ), $stat ) . '</th>';
+			echo '<th scope="col">' . sprintf( esc_html__( 'Memcache %s', 'query-monitor' ) ) . '</th>';
 		}
 		echo '</tr>';
 		echo '</thead>';
@@ -43,7 +43,7 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 			echo '<table>';
 			echo '<thead>';
 			echo '<tr>';
-			echo '<th>' . sprintf( esc_html__( 'Memcache %s commands', 'query-monitor' ), $group ) . '</th>';
+			echo '<th>' . sprintf( esc_html__( 'Memcache %s commands', 'query-monitor' ) ) . '</th>';
 			echo '<th>' . esc_html__( 'Called', 'query-monitor' ) . '</th>';
 			echo '</tr>';
 			echo '</thead>';
@@ -72,10 +72,10 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 	 *
 	 * @return array
 	 */
-	public function admin_title( array $title ) {
+	public function admin_title( array $title ): array {
 		global $wp_object_cache;
 		$title[] = sprintf(
-			esc_html__( 'Cache %d/%d', 'query-monitor' ),
+			esc_html__( 'Cache %1$d/%2$d', 'query-monitor' ),
 			intval( $wp_object_cache->stats['get'] ),
 			intval( $wp_object_cache->stats['add'] )
 		);
@@ -90,7 +90,7 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 	 *
 	 * @return array
 	 */
-	public function admin_class( array $class ) {
+	public function admin_class( array $class ): array {
 		$class[] = 'qm-memcache-stats';
 
 		return $class;
@@ -103,14 +103,15 @@ class QM_Output_Memcache_Stats extends QM_Output_Html {
 	 *
 	 * @return array
 	 */
-	public function admin_menu( array $menu ) {
-		$menu[] = $this->menu( array(
-			'id'    => 'qm-memcache-stats',
-			'href'  => '#qm-memcache-stats',
-			'title' => esc_html__( 'Memcache stats', 'query-monitor' )
-		) );
+	public function admin_menu( array $menu ): array {
+		$menu[] = $this->menu(
+			array(
+				'id'    => 'qm-memcache-stats',
+				'href'  => '#qm-memcache-stats',
+				'title' => esc_html__( 'Memcache stats', 'query-monitor' ),
+			)
+		);
 
 		return $menu;
 	}
-
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         "wpackagist-plugin/query-monitor": "^3.6"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "wp-coding-standards/wpcs": "^2.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c307974993eb97de817c33d09d899f2c",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "0bc71b624b937b96b678f920538d6257",
+    "packages": [
         {
             "name": "composer/installers",
             "version": "v1.9.0",
@@ -145,6 +144,252 @@
             "time": "2020-04-07T06:57:05+00:00"
         },
         {
+            "name": "wpackagist-plugin/query-monitor",
+            "version": "3.6.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/query-monitor/",
+                "reference": "tags/3.6.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.6.0.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/query-monitor/"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "^2|^3"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-01-29T20:22:20+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2019-11-04T15:17:54+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.5.5",
             "source": {
@@ -196,22 +441,50 @@
             "time": "2020-04-17T01:09:41+00:00"
         },
         {
-            "name": "wpackagist-plugin/query-monitor",
-            "version": "3.6.0",
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
             "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.6.0"
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.6.0.zip"
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
             },
             "require": {
-                "composer/installers": "~1.0"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/query-monitor/"
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="QM Memcache Collector Ruleset">
+    <description>QM Memcache Collector Ruleset</description>
+    <exclude-pattern>/wp-content/*</exclude-pattern>
+    <exclude-pattern>/vendor/*</exclude-pattern>
+
+    <rule ref="PHPCompatibilityWP"/>
+
+    <rule ref="WordPress-Extra">
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Add PHPCS using the WordPress-Extra and PHPCompatibilityWP standard.
Refactor code to be compatible with this standard.

Add travis integration to run phpcs on PR's.